### PR TITLE
Sync DNS cluster after zone file update

### DIFF
--- a/cgi/addon_ipmanager.cgi
+++ b/cgi/addon_ipmanager.cgi
@@ -372,7 +372,7 @@ sub changeIPInFiles {
     my $eh = IO::Handle->new();
 
     #Replace IP in DNS Zone
-    my $pid = IPC::Open3::open3( $wh, $rh, $eh, "sed -i 's/$oldip/$newip/g' /var/named/$domain.db" );
+    my $pid = IPC::Open3::open3( $wh, $rh, $eh, "sed -i 's/$oldip/$newip/g' /var/named/$domain.db && /scripts/dnscluster synczone $domain" );
     waitpid( 0, $pid );
 }
 


### PR DESCRIPTION
Hey, I've made a small change to sync the DNS cluster after editing a zone file for servers that use clustering. This should have no negative impact on servers that do not do clustering.
